### PR TITLE
ci/framework monikers

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -26,7 +26,7 @@ jobs:
         with:          
           dotnet-version: ${{ matrix.dotnet-version }}      
       - name: Restore dependencies        
-        run: dotnet restore --framework ${{ matrix.framework }}    
+        run: dotnet restore 
       - name: Build        
         run: dotnet build --no-restore --framework ${{ matrix.framework }}
       - name: Test        

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]    
   pull_request:      
     branches: [ "main" ]  
+  workflow_dispatch:
   
 jobs: 
   build:


### PR DESCRIPTION
- **ci: fixes missing moniker for dotnet commands**
- **ci: adds worfklow dispatch just in case**
- **ci: removes extraneous framework monikers**
