### PR TITLE
ci/framework monikers

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -21,10 +21,14 @@ jobs:
             framework: net9.0
     steps:
       - uses: actions/checkout@v4      
-      - name: Setup .NET        
-        uses: actions/setup-dotnet@v4        
+      - name: Setup .NET 9.x 
+        uses: actions/setup-dotnet@v4
         with:          
-          dotnet-version: ${{ matrix.dotnet-version }}      
+          dotnet-version: 9.x
+      - name: Setup .NET ${{ matrix.dotnet-version }}      
+        uses: actions/setup-dotnet@v4 
+        with:          
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Restore dependencies        
         run: dotnet restore 
       - name: Build        

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Restore dependencies        
         run: dotnet restore 
       - name: Build        
-        run: dotnet build --no-restore --framework ${{ matrix.framework }}
+        run: dotnet build --framework ${{ matrix.framework }}
       - name: Test        
         run: dotnet test --no-build --verbosity normal --framework ${{ matrix.framework }}


### PR DESCRIPTION
- **ci: fixes missing moniker for dotnet commands**
- **ci: adds worfklow dispatch just in case**
- **ci: removes extraneous framework monikers**
- **ci: adds required 9.x framework for restore**
